### PR TITLE
Add `channels` related apis

### DIFF
--- a/src/main/java/misskey4j/Misskey.java
+++ b/src/main/java/misskey4j/Misskey.java
@@ -4,6 +4,7 @@ import misskey4j.api.AccountsResource;
 import misskey4j.api.AppResource;
 import misskey4j.api.AuthResource;
 import misskey4j.api.BlocksResource;
+import misskey4j.api.ChannelsResource;
 import misskey4j.api.FavoritesResource;
 import misskey4j.api.FederationResource;
 import misskey4j.api.FilesResource;
@@ -36,6 +37,8 @@ public interface Misskey {
     UsersResource users();
 
     ListsResource lists();
+
+    ChannelsResource channels();
 
     NotesResource notes();
 

--- a/src/main/java/misskey4j/MisskeyAPI.java
+++ b/src/main/java/misskey4j/MisskeyAPI.java
@@ -83,6 +83,7 @@ public enum MisskeyAPI {
     // Channels
     // ------------------------------------------ //
 
+    ChannelsOwned("channels/owned"),
     ChannelsFollowed("channels/followed"),
     ChannelsTimeline("channels/timeline"),
 //    ChannelsMyFavorites("channels/my-favorites"), etc...

--- a/src/main/java/misskey4j/MisskeyAPI.java
+++ b/src/main/java/misskey4j/MisskeyAPI.java
@@ -84,9 +84,19 @@ public enum MisskeyAPI {
     // ------------------------------------------ //
 
     ChannelsOwned("channels/owned"),
+//    ChannelsMyFavorites("channels/my-favorites"),
+//    ChannelsCreate("channels/create"),
+//    ChannelsUnfollow("channels/unfollow"),
+//    ChannelsUpdate("channels/update"),
+//    ChannelsFavorite("channels/favorite"),
+//    ChannelsUnfavorite("channels/unfavorite"),
     ChannelsFollowed("channels/followed"),
+//    ChannelsFollow("channels/follow"),
     ChannelsTimeline("channels/timeline"),
-//    ChannelsMyFavorites("channels/my-favorites"), etc...
+    ChannelsShow("channels/show"),
+//    ChannelsSearch("channels/search"),
+//    ChannelsFeatured("channels/featured"),
+
 
     // ------------------------------------------ //
     // Following

--- a/src/main/java/misskey4j/MisskeyAPI.java
+++ b/src/main/java/misskey4j/MisskeyAPI.java
@@ -80,6 +80,13 @@ public enum MisskeyAPI {
     ListsShow("users/lists/show"),
 
     // ------------------------------------------ //
+    // Channels
+    // ------------------------------------------ //
+
+    ChannelsFollowed("channels/followed"),
+//    ChannelsMyFavorites("channels/my-favorites"), etc...
+
+    // ------------------------------------------ //
     // Following
     // ------------------------------------------ //
 

--- a/src/main/java/misskey4j/MisskeyAPI.java
+++ b/src/main/java/misskey4j/MisskeyAPI.java
@@ -84,7 +84,7 @@ public enum MisskeyAPI {
     // ------------------------------------------ //
 
     ChannelsOwned("channels/owned"),
-//    ChannelsMyFavorites("channels/my-favorites"),
+    ChannelsMyFavorites("channels/my-favorites"),
 //    ChannelsCreate("channels/create"),
 //    ChannelsUnfollow("channels/unfollow"),
 //    ChannelsUpdate("channels/update"),

--- a/src/main/java/misskey4j/MisskeyAPI.java
+++ b/src/main/java/misskey4j/MisskeyAPI.java
@@ -84,6 +84,7 @@ public enum MisskeyAPI {
     // ------------------------------------------ //
 
     ChannelsFollowed("channels/followed"),
+    ChannelsTimeline("channels/timeline"),
 //    ChannelsMyFavorites("channels/my-favorites"), etc...
 
     // ------------------------------------------ //

--- a/src/main/java/misskey4j/api/ChannelsResource.java
+++ b/src/main/java/misskey4j/api/ChannelsResource.java
@@ -1,0 +1,17 @@
+package misskey4j.api;
+
+import misskey4j.api.request.ChannelsFollowedRequest;
+import misskey4j.api.response.ChannelsFollowedResponse;
+import misskey4j.entity.share.Response;
+
+public interface ChannelsResource {
+
+    /**
+     * フォローしているチャンネル一覧を取得します。
+     *
+     * @see "https://misskey.io/api-doc#tag/channels/operation/channels/followed"
+     */
+    Response<ChannelsFollowedResponse[]> followed(
+            ChannelsFollowedRequest request);
+
+}

--- a/src/main/java/misskey4j/api/ChannelsResource.java
+++ b/src/main/java/misskey4j/api/ChannelsResource.java
@@ -1,10 +1,12 @@
 package misskey4j.api;
 
 import misskey4j.api.request.ChannelsFollowedRequest;
+import misskey4j.api.request.ChannelsMyFavoritesRequest;
 import misskey4j.api.request.ChannelsOwnedRequest;
 import misskey4j.api.request.ChannelsShowRequest;
 import misskey4j.api.request.ChannelsTimelineRequest;
 import misskey4j.api.response.ChannelsFollowedResponse;
+import misskey4j.api.response.ChannelsMyFavoritesResponse;
 import misskey4j.api.response.ChannelsOwnedResponse;
 import misskey4j.api.response.ChannelsShowResponse;
 import misskey4j.api.response.ChannelsTimelineResponse;
@@ -18,6 +20,13 @@ public interface ChannelsResource {
      * @see "https://misskey.io/api-doc#tag/channels/operation/channels/owned"
      */
     Response<ChannelsOwnedResponse[]> owned(ChannelsOwnedRequest request);
+
+    /**
+     * お気に入りのチャンネル一覧を取得します。
+     *
+     * @see "https://misskey.io/api-doc#tag/channels/operation/channels/my-favorites"
+     */
+    Response<ChannelsMyFavoritesResponse[]> myFavorites(ChannelsMyFavoritesRequest request);
 
     /**
      * フォローしているチャンネル一覧を取得します。

--- a/src/main/java/misskey4j/api/ChannelsResource.java
+++ b/src/main/java/misskey4j/api/ChannelsResource.java
@@ -2,9 +2,11 @@ package misskey4j.api;
 
 import misskey4j.api.request.ChannelsFollowedRequest;
 import misskey4j.api.request.ChannelsOwnedRequest;
+import misskey4j.api.request.ChannelsShowRequest;
 import misskey4j.api.request.ChannelsTimelineRequest;
 import misskey4j.api.response.ChannelsFollowedResponse;
 import misskey4j.api.response.ChannelsOwnedResponse;
+import misskey4j.api.response.ChannelsShowResponse;
 import misskey4j.api.response.ChannelsTimelineResponse;
 import misskey4j.entity.share.Response;
 
@@ -31,4 +33,10 @@ public interface ChannelsResource {
      */
     Response<ChannelsTimelineResponse[]> timeline(ChannelsTimelineRequest request);
 
+    /**
+     * 指定したチャンネルの情報を取得します。
+     *
+     * @see "https://misskey.io/api-doc#tag/notes/operation/channels/show"
+     */
+    Response<ChannelsShowResponse> show(ChannelsShowRequest request);
 }

--- a/src/main/java/misskey4j/api/ChannelsResource.java
+++ b/src/main/java/misskey4j/api/ChannelsResource.java
@@ -1,7 +1,9 @@
 package misskey4j.api;
 
 import misskey4j.api.request.ChannelsFollowedRequest;
+import misskey4j.api.request.ChannelsTimelineRequest;
 import misskey4j.api.response.ChannelsFollowedResponse;
+import misskey4j.api.response.ChannelsTimelineResponse;
 import misskey4j.entity.share.Response;
 
 public interface ChannelsResource {
@@ -13,5 +15,13 @@ public interface ChannelsResource {
      */
     Response<ChannelsFollowedResponse[]> followed(
             ChannelsFollowedRequest request);
+
+    /**
+     * 指定したチャンネルのタイムラインを取得します。
+     *
+     * @see "https://misskey.io/api-doc#tag/notes/operation/channels/timeline"
+     */
+    Response<ChannelsTimelineResponse[]> timeline(
+            ChannelsTimelineRequest request);
 
 }

--- a/src/main/java/misskey4j/api/ChannelsResource.java
+++ b/src/main/java/misskey4j/api/ChannelsResource.java
@@ -1,27 +1,34 @@
 package misskey4j.api;
 
 import misskey4j.api.request.ChannelsFollowedRequest;
+import misskey4j.api.request.ChannelsOwnedRequest;
 import misskey4j.api.request.ChannelsTimelineRequest;
 import misskey4j.api.response.ChannelsFollowedResponse;
+import misskey4j.api.response.ChannelsOwnedResponse;
 import misskey4j.api.response.ChannelsTimelineResponse;
 import misskey4j.entity.share.Response;
 
 public interface ChannelsResource {
 
     /**
+     * 管理しているチャンネル一覧を取得します。
+     *
+     * @see "https://misskey.io/api-doc#tag/channels/operation/channels/owned"
+     */
+    Response<ChannelsOwnedResponse[]> owned(ChannelsOwnedRequest request);
+
+    /**
      * フォローしているチャンネル一覧を取得します。
      *
      * @see "https://misskey.io/api-doc#tag/channels/operation/channels/followed"
      */
-    Response<ChannelsFollowedResponse[]> followed(
-            ChannelsFollowedRequest request);
+    Response<ChannelsFollowedResponse[]> followed(ChannelsFollowedRequest request);
 
     /**
      * 指定したチャンネルのタイムラインを取得します。
      *
      * @see "https://misskey.io/api-doc#tag/notes/operation/channels/timeline"
      */
-    Response<ChannelsTimelineResponse[]> timeline(
-            ChannelsTimelineRequest request);
+    Response<ChannelsTimelineResponse[]> timeline(ChannelsTimelineRequest request);
 
 }

--- a/src/main/java/misskey4j/api/request/ChannelsFollowedRequest.java
+++ b/src/main/java/misskey4j/api/request/ChannelsFollowedRequest.java
@@ -1,0 +1,65 @@
+package misskey4j.api.request;
+
+import misskey4j.api.model.TokenRequest;
+import misskey4j.api.request.protocol.PagingBuilder;
+
+public class ChannelsFollowedRequest extends TokenRequest {
+
+    public static ChannelsFollowedRequestBuilder builder() {
+        return new ChannelsFollowedRequestBuilder();
+    }
+
+    private Long limit;
+    private String sinceId;
+    private String untilId;
+
+    // region
+    public Long getLimit() {
+        return limit;
+    }
+
+    public String getSinceId() {
+        return sinceId;
+    }
+
+    public String getUntilId() {
+        return untilId;
+    }
+
+    public static final class ChannelsFollowedRequestBuilder implements PagingBuilder<ChannelsFollowedRequestBuilder> {
+
+        private Long limit;
+        private String sinceId;
+        private String untilId;
+
+        private ChannelsFollowedRequestBuilder() {
+        }
+
+        @Override
+        public ChannelsFollowedRequestBuilder limit(Long limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        @Override
+        public ChannelsFollowedRequestBuilder sinceId(String sinceId) {
+            this.sinceId = sinceId;
+            return this;
+        }
+
+        @Override
+        public ChannelsFollowedRequestBuilder untilId(String untilId) {
+            this.untilId = untilId;
+            return this;
+        }
+
+        public ChannelsFollowedRequest build() {
+            ChannelsFollowedRequest channelsFollowedRequest = new ChannelsFollowedRequest();
+            channelsFollowedRequest.sinceId = this.sinceId;
+            channelsFollowedRequest.limit = this.limit;
+            channelsFollowedRequest.untilId = this.untilId;
+            return channelsFollowedRequest;
+        }
+    }
+    // endregion
+}

--- a/src/main/java/misskey4j/api/request/ChannelsMyFavoritesRequest.java
+++ b/src/main/java/misskey4j/api/request/ChannelsMyFavoritesRequest.java
@@ -1,0 +1,22 @@
+package misskey4j.api.request;
+
+import misskey4j.api.model.TokenRequest;
+
+public class ChannelsMyFavoritesRequest extends TokenRequest {
+
+    public static ChannelsMyFavoritesBuilder builder() {
+        return new ChannelsMyFavoritesBuilder();
+    }
+
+    // region
+    public static final class ChannelsMyFavoritesBuilder {
+
+        private ChannelsMyFavoritesBuilder() {
+        }
+
+        public ChannelsMyFavoritesRequest build() {
+            return new ChannelsMyFavoritesRequest();
+        }
+    }
+    // endregion
+}

--- a/src/main/java/misskey4j/api/request/ChannelsOwnedRequest.java
+++ b/src/main/java/misskey4j/api/request/ChannelsOwnedRequest.java
@@ -3,10 +3,10 @@ package misskey4j.api.request;
 import misskey4j.api.model.TokenRequest;
 import misskey4j.api.request.protocol.PagingBuilder;
 
-public class ChannelsFollowedRequest extends TokenRequest {
+public class ChannelsOwnedRequest extends TokenRequest {
 
-    public static ChannelsFollowedRequestBuilder builder() {
-        return new ChannelsFollowedRequestBuilder();
+    public static ChannelsOwnedRequestBuilder builder() {
+        return new ChannelsOwnedRequestBuilder();
     }
 
     private Long limit;
@@ -26,35 +26,35 @@ public class ChannelsFollowedRequest extends TokenRequest {
         return untilId;
     }
 
-    public static final class ChannelsFollowedRequestBuilder implements PagingBuilder<ChannelsFollowedRequestBuilder> {
+    public static final class ChannelsOwnedRequestBuilder implements PagingBuilder<ChannelsOwnedRequestBuilder> {
 
         private Long limit;
         private String sinceId;
         private String untilId;
 
-        private ChannelsFollowedRequestBuilder() {
+        private ChannelsOwnedRequestBuilder() {
         }
 
         @Override
-        public ChannelsFollowedRequestBuilder limit(Long limit) {
+        public ChannelsOwnedRequestBuilder limit(Long limit) {
             this.limit = limit;
             return this;
         }
 
         @Override
-        public ChannelsFollowedRequestBuilder sinceId(String sinceId) {
+        public ChannelsOwnedRequestBuilder sinceId(String sinceId) {
             this.sinceId = sinceId;
             return this;
         }
 
         @Override
-        public ChannelsFollowedRequestBuilder untilId(String untilId) {
+        public ChannelsOwnedRequestBuilder untilId(String untilId) {
             this.untilId = untilId;
             return this;
         }
 
-        public ChannelsFollowedRequest build() {
-            ChannelsFollowedRequest request = new ChannelsFollowedRequest();
+        public ChannelsOwnedRequest build() {
+            ChannelsOwnedRequest request = new ChannelsOwnedRequest();
             request.sinceId = this.sinceId;
             request.limit = this.limit;
             request.untilId = this.untilId;

--- a/src/main/java/misskey4j/api/request/ChannelsShowRequest.java
+++ b/src/main/java/misskey4j/api/request/ChannelsShowRequest.java
@@ -1,0 +1,37 @@
+package misskey4j.api.request;
+
+import misskey4j.api.model.TokenRequest;
+
+public class ChannelsShowRequest extends TokenRequest {
+
+    public static ChannelsShowRequestBuilder builder() {
+        return new ChannelsShowRequestBuilder();
+    }
+
+    private String channelId;
+
+    // region
+    public String getChannelId() {
+        return channelId;
+    }
+
+    public static final class ChannelsShowRequestBuilder {
+
+        private String channelId;
+
+        private ChannelsShowRequestBuilder() {
+        }
+
+        public ChannelsShowRequestBuilder channelId(String channelId) {
+            this.channelId = channelId;
+            return this;
+        }
+
+        public ChannelsShowRequest build() {
+            ChannelsShowRequest channelsTimelineRequest = new ChannelsShowRequest();
+            channelsTimelineRequest.channelId = this.channelId;
+            return channelsTimelineRequest;
+        }
+    }
+    // endregion
+}

--- a/src/main/java/misskey4j/api/request/ChannelsTimelineRequest.java
+++ b/src/main/java/misskey4j/api/request/ChannelsTimelineRequest.java
@@ -1,0 +1,101 @@
+package misskey4j.api.request;
+
+import misskey4j.api.model.TokenRequest;
+import misskey4j.api.request.protocol.FullPagingBuilder;
+
+public class ChannelsTimelineRequest extends TokenRequest {
+
+    public static ChannelsTimelineRequestBuilder builder() {
+        return new ChannelsTimelineRequestBuilder();
+    }
+
+    private String channelId;
+
+    private Long limit;
+
+    private String sinceId;
+    private String untilId;
+    private Long sinceDate;
+    private Long untilDate;
+
+    // region
+    public String getChannelId() {
+        return channelId;
+    }
+
+    public Long getLimit() {
+        return limit;
+    }
+
+    public String getSinceId() {
+        return sinceId;
+    }
+
+    public String getUntilId() {
+        return untilId;
+    }
+
+    public Long getSinceDate() {
+        return sinceDate;
+    }
+
+    public Long getUntilDate() {
+        return untilDate;
+    }
+
+    public static final class ChannelsTimelineRequestBuilder
+            implements FullPagingBuilder<ChannelsTimelineRequestBuilder> {
+
+        private String channelId;
+        private Long limit;
+        private String sinceId;
+        private String untilId;
+        private Long sinceDate;
+        private Long untilDate;
+
+        private ChannelsTimelineRequestBuilder() {
+        }
+
+        public ChannelsTimelineRequestBuilder channelId(String channelId) {
+            this.channelId = channelId;
+            return this;
+        }
+
+        public ChannelsTimelineRequestBuilder limit(Long limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public ChannelsTimelineRequestBuilder sinceId(String sinceId) {
+            this.sinceId = sinceId;
+            return this;
+        }
+
+        public ChannelsTimelineRequestBuilder untilId(String untilId) {
+            this.untilId = untilId;
+            return this;
+        }
+
+        public ChannelsTimelineRequestBuilder sinceDate(Long sinceDate) {
+            this.sinceDate = sinceDate;
+            return this;
+        }
+
+        public ChannelsTimelineRequestBuilder untilDate(Long untilDate) {
+            this.untilDate = untilDate;
+            return this;
+        }
+
+        public ChannelsTimelineRequest build() {
+            ChannelsTimelineRequest channelsTimelineRequest = new ChannelsTimelineRequest();
+            channelsTimelineRequest.channelId = this.channelId;
+            channelsTimelineRequest.limit = this.limit;
+            channelsTimelineRequest.sinceId = this.sinceId;
+            channelsTimelineRequest.untilId = this.untilId;
+            channelsTimelineRequest.sinceDate = this.sinceDate;
+            channelsTimelineRequest.untilDate = this.untilDate;
+            return channelsTimelineRequest;
+        }
+    }
+    // endregion
+}

--- a/src/main/java/misskey4j/api/request/notes/NotesCreateRequest.java
+++ b/src/main/java/misskey4j/api/request/notes/NotesCreateRequest.java
@@ -2,8 +2,10 @@ package misskey4j.api.request.notes;
 
 import misskey4j.api.model.PollRequest;
 import misskey4j.api.model.TokenRequest;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+
 
 public class NotesCreateRequest extends TokenRequest {
 
@@ -26,6 +28,9 @@ public class NotesCreateRequest extends TokenRequest {
     private List<String> fileIds;
     private String replyId;
     private String renoteId;
+
+    @Nullable
+    private String channelId;
 
     private PollRequest poll;
 
@@ -78,6 +83,11 @@ public class NotesCreateRequest extends TokenRequest {
         return renoteId;
     }
 
+    @Nullable
+    public String getChannelId() {
+        return channelId;
+    }
+
     public PollRequest getPoll() {
         return poll;
     }
@@ -95,6 +105,7 @@ public class NotesCreateRequest extends TokenRequest {
         private List<String> fileIds;
         private String replyId;
         private String renoteId;
+        @Nullable private String channelId;
         private PollRequest poll;
 
         private NotesCreateRequestBuilder() {
@@ -160,6 +171,11 @@ public class NotesCreateRequest extends TokenRequest {
             return this;
         }
 
+        public NotesCreateRequestBuilder channelId(String channelId) {
+            this.channelId = channelId;
+            return this;
+        }
+
         public NotesCreateRequestBuilder poll(PollRequest poll) {
             this.poll = poll;
             return this;
@@ -173,6 +189,7 @@ public class NotesCreateRequest extends TokenRequest {
             notesCreateRequest.fileIds = this.fileIds;
             notesCreateRequest.cw = this.cw;
             notesCreateRequest.renoteId = this.renoteId;
+            notesCreateRequest.channelId = this.channelId;
             notesCreateRequest.noExtractHashtags = this.noExtractHashtags;
             notesCreateRequest.replyId = this.replyId;
             notesCreateRequest.visibleUserIds = this.visibleUserIds;

--- a/src/main/java/misskey4j/api/request/notes/NotesCreateRequest.java
+++ b/src/main/java/misskey4j/api/request/notes/NotesCreateRequest.java
@@ -1,10 +1,11 @@
 package misskey4j.api.request.notes;
 
+import java.util.List;
+
+import javax.annotation.Nullable;
+
 import misskey4j.api.model.PollRequest;
 import misskey4j.api.model.TokenRequest;
-import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
 
 
 public class NotesCreateRequest extends TokenRequest {

--- a/src/main/java/misskey4j/api/response/ChannelsFollowedResponse.java
+++ b/src/main/java/misskey4j/api/response/ChannelsFollowedResponse.java
@@ -1,0 +1,6 @@
+package misskey4j.api.response;
+
+import misskey4j.entity.Channel;
+
+public class ChannelsFollowedResponse extends Channel {
+}

--- a/src/main/java/misskey4j/api/response/ChannelsMyFavoritesResponse.java
+++ b/src/main/java/misskey4j/api/response/ChannelsMyFavoritesResponse.java
@@ -1,0 +1,6 @@
+package misskey4j.api.response;
+
+import misskey4j.entity.Channel;
+
+public class ChannelsMyFavoritesResponse extends Channel {
+}

--- a/src/main/java/misskey4j/api/response/ChannelsOwnedResponse.java
+++ b/src/main/java/misskey4j/api/response/ChannelsOwnedResponse.java
@@ -1,0 +1,6 @@
+package misskey4j.api.response;
+
+import misskey4j.entity.Channel;
+
+public class ChannelsOwnedResponse extends Channel {
+}

--- a/src/main/java/misskey4j/api/response/ChannelsShowResponse.java
+++ b/src/main/java/misskey4j/api/response/ChannelsShowResponse.java
@@ -1,0 +1,6 @@
+package misskey4j.api.response;
+
+import misskey4j.entity.Channel;
+
+public class ChannelsShowResponse extends Channel {
+}

--- a/src/main/java/misskey4j/api/response/ChannelsTimelineResponse.java
+++ b/src/main/java/misskey4j/api/response/ChannelsTimelineResponse.java
@@ -1,0 +1,6 @@
+package misskey4j.api.response;
+
+import misskey4j.entity.Note;
+
+public class ChannelsTimelineResponse extends Note {
+}

--- a/src/main/java/misskey4j/entity/Channel.java
+++ b/src/main/java/misskey4j/entity/Channel.java
@@ -1,8 +1,8 @@
 package misskey4j.entity;
 
-import org.jetbrains.annotations.Nullable;
-
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 public class Channel {
 

--- a/src/main/java/misskey4j/entity/Channel.java
+++ b/src/main/java/misskey4j/entity/Channel.java
@@ -1,0 +1,160 @@
+package misskey4j.entity;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class Channel {
+
+    private String id;
+
+    private String createdAt;
+
+    @Nullable
+    private String lastNotedAt;
+
+    private String name;
+
+    @Nullable
+    private String description;
+
+    @Nullable
+    private String bannerUrl;
+
+    private boolean isArchived;
+
+    private int notesCount;
+
+    private int usersCount;
+
+    private boolean isFollowing;
+
+    private boolean isFavorited;
+
+    @Nullable
+    private String userId;
+
+    private java.util.List<String> pinnedNoteIds;
+
+    private String color;
+
+    // region
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @Nullable
+    public String getLastNotedAt() {
+        return lastNotedAt;
+    }
+
+    public void setLastNotedAt(@Nullable String lastNotedAt) {
+        this.lastNotedAt = lastNotedAt;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(@Nullable String description) {
+        this.description = description;
+    }
+
+    @Nullable
+    public String getBannerUrl() {
+        return bannerUrl;
+    }
+
+    public void setBannerUrl(@Nullable String bannerUrl) {
+        this.bannerUrl = bannerUrl;
+    }
+
+    public boolean isArchived() {
+        return isArchived;
+    }
+
+    public void setArchived(boolean archived) {
+        isArchived = archived;
+    }
+
+    public int getNotesCount() {
+        return notesCount;
+    }
+
+    public void setNotesCount(int notesCount) {
+        this.notesCount = notesCount;
+    }
+
+    public int getUsersCount() {
+        return usersCount;
+    }
+
+    public void setUsersCount(int usersCount) {
+        this.usersCount = usersCount;
+    }
+
+    public boolean isFollowing() {
+        return isFollowing;
+    }
+
+    public void setFollowing(boolean following) {
+        isFollowing = following;
+    }
+
+    public boolean isFavorited() {
+        return isFavorited;
+    }
+
+    public void setFavorited(boolean favorited) {
+        isFavorited = favorited;
+    }
+
+    @Nullable
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(@Nullable String userId) {
+        this.userId = userId;
+    }
+
+    public List<String> getPinnedNoteIds() {
+        return pinnedNoteIds;
+    }
+
+    public void setPinnedNoteIds(List<String> pinnedNoteIds) {
+        this.pinnedNoteIds = pinnedNoteIds;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+
+    // endregion
+}

--- a/src/main/java/misskey4j/entity/contant/Scope.java
+++ b/src/main/java/misskey4j/entity/contant/Scope.java
@@ -38,6 +38,10 @@ public class Scope {
             Scope.read().userGroups(),
             Scope.write().userGroups(),
 
+            // Channels
+            Scope.read().channels(),
+            Scope.write().channels(),
+
             // Write Only
             Scope.write().notes(),
             Scope.write().votes()
@@ -142,6 +146,10 @@ public class Scope {
 
         public Scope userGroups() {
             return new Scope(operation, "user-groups");
+        }
+
+        public Scope channels() {
+            return new Scope(operation, "channels");
         }
     }
 }

--- a/src/main/java/misskey4j/internal/MisskeyImpl.java
+++ b/src/main/java/misskey4j/internal/MisskeyImpl.java
@@ -5,6 +5,7 @@ import misskey4j.api.AccountsResource;
 import misskey4j.api.AppResource;
 import misskey4j.api.AuthResource;
 import misskey4j.api.BlocksResource;
+import misskey4j.api.ChannelsResource;
 import misskey4j.api.FavoritesResource;
 import misskey4j.api.FederationResource;
 import misskey4j.api.FilesResource;
@@ -24,6 +25,7 @@ import misskey4j.internal.api.AccountsResourceImpl;
 import misskey4j.internal.api.AppResourceImpl;
 import misskey4j.internal.api.AuthResourceImpl;
 import misskey4j.internal.api.BlocksResourceImpl;
+import misskey4j.internal.api.ChannelsResourceImpl;
 import misskey4j.internal.api.FavoritesResourceImpl;
 import misskey4j.internal.api.FederationResourceImpl;
 import misskey4j.internal.api.FilesResourceImpl;
@@ -52,6 +54,7 @@ public class MisskeyImpl implements Misskey {
     private final AccountsResource accounts;
     private final UsersResource users;
     private final ListsResource lists;
+    private final ChannelsResource channels;
     private final NotesResource notes;
     private final MutesResource mutes;
     private final BlocksResource blocks;
@@ -81,6 +84,7 @@ public class MisskeyImpl implements Misskey {
         accounts = new AccountsResourceImpl(url, i);
         users = new UsersResourceImpl(url, i);
         lists = new ListsResourceImpl(url, i);
+        channels = new ChannelsResourceImpl(url, i);
         notes = new NotesResourceImpl(url, i);
 
         reactions = new ReactionsResourceImpl(url, i);
@@ -129,6 +133,11 @@ public class MisskeyImpl implements Misskey {
     @Override
     public ListsResource lists() {
         return lists;
+    }
+
+    @Override
+    public ChannelsResource channels() {
+        return channels;
     }
 
     @Override

--- a/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
+++ b/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
@@ -4,9 +4,11 @@ import misskey4j.MisskeyAPI;
 import misskey4j.api.ChannelsResource;
 import misskey4j.api.request.ChannelsFollowedRequest;
 import misskey4j.api.request.ChannelsOwnedRequest;
+import misskey4j.api.request.ChannelsShowRequest;
 import misskey4j.api.request.ChannelsTimelineRequest;
 import misskey4j.api.response.ChannelsFollowedResponse;
 import misskey4j.api.response.ChannelsOwnedResponse;
+import misskey4j.api.response.ChannelsShowResponse;
 import misskey4j.api.response.ChannelsTimelineResponse;
 import misskey4j.entity.share.Response;
 
@@ -42,4 +44,14 @@ public class ChannelsResourceImpl extends AbstractResourceImpl implements Channe
         return post(ChannelsTimelineResponse[].class,
                 MisskeyAPI.ChannelsTimeline.code(), request);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Response<ChannelsShowResponse> show(ChannelsShowRequest request) {
+        return post(ChannelsShowResponse.class,
+                MisskeyAPI.ChannelsShow.code(), request);
+    }
+
 }

--- a/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
+++ b/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
@@ -3,10 +3,12 @@ package misskey4j.internal.api;
 import misskey4j.MisskeyAPI;
 import misskey4j.api.ChannelsResource;
 import misskey4j.api.request.ChannelsFollowedRequest;
+import misskey4j.api.request.ChannelsMyFavoritesRequest;
 import misskey4j.api.request.ChannelsOwnedRequest;
 import misskey4j.api.request.ChannelsShowRequest;
 import misskey4j.api.request.ChannelsTimelineRequest;
 import misskey4j.api.response.ChannelsFollowedResponse;
+import misskey4j.api.response.ChannelsMyFavoritesResponse;
 import misskey4j.api.response.ChannelsOwnedResponse;
 import misskey4j.api.response.ChannelsShowResponse;
 import misskey4j.api.response.ChannelsTimelineResponse;
@@ -25,6 +27,15 @@ public class ChannelsResourceImpl extends AbstractResourceImpl implements Channe
     public Response<ChannelsOwnedResponse[]> owned(ChannelsOwnedRequest request) {
         return post(ChannelsOwnedResponse[].class,
                 MisskeyAPI.ChannelsOwned.code(), request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Response<ChannelsMyFavoritesResponse[]> myFavorites(ChannelsMyFavoritesRequest request) {
+        return post(ChannelsMyFavoritesResponse[].class,
+                MisskeyAPI.ChannelsMyFavorites.code(), request);
     }
 
     /**

--- a/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
+++ b/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
@@ -3,8 +3,10 @@ package misskey4j.internal.api;
 import misskey4j.MisskeyAPI;
 import misskey4j.api.ChannelsResource;
 import misskey4j.api.request.ChannelsFollowedRequest;
+import misskey4j.api.request.ChannelsOwnedRequest;
 import misskey4j.api.request.ChannelsTimelineRequest;
 import misskey4j.api.response.ChannelsFollowedResponse;
+import misskey4j.api.response.ChannelsOwnedResponse;
 import misskey4j.api.response.ChannelsTimelineResponse;
 import misskey4j.entity.share.Response;
 
@@ -12,6 +14,15 @@ public class ChannelsResourceImpl extends AbstractResourceImpl implements Channe
 
     public ChannelsResourceImpl(String uri, String i) {
         super(uri, i);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Response<ChannelsOwnedResponse[]> owned(ChannelsOwnedRequest request) {
+        return post(ChannelsOwnedResponse[].class,
+                MisskeyAPI.ChannelsOwned.code(), request);
     }
 
     /**

--- a/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
+++ b/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
@@ -1,0 +1,23 @@
+package misskey4j.internal.api;
+
+import misskey4j.MisskeyAPI;
+import misskey4j.api.ChannelsResource;
+import misskey4j.api.request.ChannelsFollowedRequest;
+import misskey4j.api.response.ChannelsFollowedResponse;
+import misskey4j.entity.share.Response;
+
+public class ChannelsResourceImpl extends AbstractResourceImpl implements ChannelsResource {
+
+    public ChannelsResourceImpl(String uri, String i) {
+        super(uri, i);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Response<ChannelsFollowedResponse[]> followed(ChannelsFollowedRequest request) {
+        return post(ChannelsFollowedResponse[].class,
+                MisskeyAPI.ChannelsFollowed.code(), request);
+    }
+}

--- a/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
+++ b/src/main/java/misskey4j/internal/api/ChannelsResourceImpl.java
@@ -3,7 +3,9 @@ package misskey4j.internal.api;
 import misskey4j.MisskeyAPI;
 import misskey4j.api.ChannelsResource;
 import misskey4j.api.request.ChannelsFollowedRequest;
+import misskey4j.api.request.ChannelsTimelineRequest;
 import misskey4j.api.response.ChannelsFollowedResponse;
+import misskey4j.api.response.ChannelsTimelineResponse;
 import misskey4j.entity.share.Response;
 
 public class ChannelsResourceImpl extends AbstractResourceImpl implements ChannelsResource {
@@ -19,5 +21,14 @@ public class ChannelsResourceImpl extends AbstractResourceImpl implements Channe
     public Response<ChannelsFollowedResponse[]> followed(ChannelsFollowedRequest request) {
         return post(ChannelsFollowedResponse[].class,
                 MisskeyAPI.ChannelsFollowed.code(), request);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Response<ChannelsTimelineResponse[]> timeline(ChannelsTimelineRequest request) {
+        return post(ChannelsTimelineResponse[].class,
+                MisskeyAPI.ChannelsTimeline.code(), request);
     }
 }


### PR DESCRIPTION
下記のチャンネル関連APIを追加しました。

- `channels/owned`
- `channels/my-favorites`
- `channels/followed`
- `channels/timeline`
- `channels/show`

また、チャンネルの読み取り/書き込み権限が必要なので `channels` の `scope` を追加しました。

さらに、ノート作成時に channelId を指定することでチャンネルへの投稿をできるようにしました。
