### PR TITLE
Add note events stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .idea
 /build/
 /out/
+/bin/
 secrets.json

--- a/src/main/java/misskey4j/entity/DeletedNote.java
+++ b/src/main/java/misskey4j/entity/DeletedNote.java
@@ -1,0 +1,31 @@
+package misskey4j.entity;
+
+import javax.annotation.Nullable;
+
+public class DeletedNote {
+
+    @Nullable
+    private String id;
+
+    private String deletedAt;
+
+    // region
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Nullable
+    public String getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(@Nullable String deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+    // endregion
+
+}

--- a/src/main/java/misskey4j/entity/Reaction.java
+++ b/src/main/java/misskey4j/entity/Reaction.java
@@ -1,0 +1,47 @@
+package misskey4j.entity;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class Reaction {
+
+    @Nullable
+    private String noteId;
+
+    @Nonnull
+    private String userId = "";
+
+    @Nullable
+    private String reaction;
+
+    // TODO: emoji
+
+    // region
+
+    @Nullable
+    public String getNoteId() {
+        return noteId;
+    }
+
+    public void setNoteId(@Nullable String id) {
+        this.noteId = id;
+    }
+
+    @Nonnull
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(@Nonnull String userId) {
+        this.userId = userId;
+    }
+
+    @Nullable
+    public String getReaction() {
+        return reaction;
+    }
+
+    public void setReaction(@Nullable String reaction) {
+        this.reaction = reaction;
+    } // endregion
+}

--- a/src/main/java/misskey4j/stream/MisskeyStream.java
+++ b/src/main/java/misskey4j/stream/MisskeyStream.java
@@ -1,13 +1,16 @@
 package misskey4j.stream;
 
+import java.util.Collections;
+
+import javax.annotation.CheckReturnValue;
+
 import misskey4j.Misskey;
 import misskey4j.stream.callback.ClosedCallback;
 import misskey4j.stream.callback.ErrorCallback;
 import misskey4j.stream.callback.EventCallback;
 import misskey4j.stream.callback.NoteCallback;
 import misskey4j.stream.callback.OpenedCallback;
-
-import java.util.Collections;
+import misskey4j.stream.callback.TimelineCallback;
 
 public class MisskeyStream {
 
@@ -53,35 +56,47 @@ public class MisskeyStream {
      * Notifications
      */
     public void main(EventCallback callback) {
-        client.subscribe("main", null, Collections.singletonList(callback));
+        client.connect("main", null, Collections.singletonList(callback));
     }
 
     /**
      * HomeTimeLine Events
      */
-    public void homeTimeLine(NoteCallback callback) {
-        client.subscribe("homeTimeline", null, Collections.singletonList(callback));
+    public void homeTimeLine(TimelineCallback callback) {
+        client.connect("homeTimeline", null, Collections.singletonList(callback));
     }
 
     /**
      * LocalTimeline Events
      */
-    public void localTimeline(NoteCallback callback) {
-        client.subscribe("localTimeline", null, Collections.singletonList(callback));
+    public void localTimeline(TimelineCallback callback) {
+        client.connect("localTimeline", null, Collections.singletonList(callback));
     }
 
     /**
      * HybridTimeline Events
      */
-    public void hybridTimeline(NoteCallback callback) {
-        client.subscribe("hybridTimeline", null, Collections.singletonList(callback));
+    public void hybridTimeline(TimelineCallback callback) {
+        client.connect("hybridTimeline", null, Collections.singletonList(callback));
     }
 
     /**
      * GlobalTimeline Events
      */
-    public void globalTimeline(NoteCallback callback) {
-        client.subscribe("globalTimeline", null, Collections.singletonList(callback));
+    public void globalTimeline(TimelineCallback callback) {
+        client.connect("globalTimeline", null, Collections.singletonList(callback));
+    }
+
+    /**
+     * Listen note Events
+     */
+    public void note(String noteId, NoteCallback callback) {
+        client.subscribeToNote(noteId, null, Collections.singletonList(callback));
+    }
+
+    @CheckReturnValue
+    public Unsubscribe unsubscribe() {
+        return new Unsubscribe(client);
     }
 
     public void setOpenedCallback(OpenedCallback openedCallback) {
@@ -94,5 +109,56 @@ public class MisskeyStream {
 
     public void setErrorCallback(ErrorCallback errorCallback) {
         client.setErrorCallback(errorCallback);
+    }
+
+    protected class Unsubscribe {
+
+        private StreamClient client;
+
+        protected Unsubscribe(StreamClient client) {
+            this.client = client;
+        }
+
+        /**
+         * Notifications
+         */
+        public void main() {
+            client.disconnect("main");
+        }
+
+        /**
+         * HomeTimeLine Events
+         */
+        public void homeTimeLine() {
+            client.disconnect("homeTimeline");
+        }
+
+        /**
+         * LocalTimeline Events
+         */
+        public void localTimeline() {
+            client.disconnect("localTimeline");
+        }
+
+        /**
+         * HybridTimeline Events
+         */
+        public void hybridTimeline() {
+            client.disconnect("hybridTimeline");
+        }
+
+        /**
+         * GlobalTimeline Events
+         */
+        public void globalTimeline() {
+            client.disconnect("globalTimeline");
+        }
+
+        /**
+         * Stop listening to note Events
+         */
+        public void note(String noteId) {
+            client.unsubscribe(noteId);
+        }
     }
 }

--- a/src/main/java/misskey4j/stream/callback/NoteCallback.java
+++ b/src/main/java/misskey4j/stream/callback/NoteCallback.java
@@ -1,7 +1,13 @@
 package misskey4j.stream.callback;
 
-import misskey4j.entity.Note;
+import misskey4j.entity.DeletedNote;
+import misskey4j.entity.Reaction;
 
 public interface NoteCallback extends EventCallback {
-    void onNoteUpdate(Note note);
+
+    void onReacted(Reaction reaction);
+
+    void onUnreacted(Reaction reaction);
+
+    void onNoteDeleted(DeletedNote note);
 }

--- a/src/main/java/misskey4j/stream/callback/TimelineCallback.java
+++ b/src/main/java/misskey4j/stream/callback/TimelineCallback.java
@@ -1,0 +1,7 @@
+package misskey4j.stream.callback;
+
+import misskey4j.entity.Note;
+
+public interface TimelineCallback extends EventCallback {
+    void onNoteUpdate(Note note);
+}

--- a/src/main/java/misskey4j/stream/model/StreamRequest.java
+++ b/src/main/java/misskey4j/stream/model/StreamRequest.java
@@ -1,5 +1,7 @@
 package misskey4j.stream.model;
 
+import javax.annotation.Nullable;
+
 public class StreamRequest<T> {
 
     private String type;
@@ -25,11 +27,16 @@ public class StreamRequest<T> {
 
     public static class Body<T> {
 
+        @Nullable
         private String channel;
+
         private String id;
+
+        @Nullable
         private T params;
 
         // region
+        @Nullable
         public String getChannel() {
             return channel;
         }
@@ -46,6 +53,7 @@ public class StreamRequest<T> {
             this.id = id;
         }
 
+        @Nullable
         public T getParams() {
             return params;
         }


### PR DESCRIPTION
Hello ^^

Here is a pull request to add these improvments :

- [X] Provide possibility to stream events on a single note
     - Events managed are : `reacted`, `unreacted` and `deleted`
- [X] Provide api to unsubscribe from streams (timelines AND single notes streams)
- [X] Some refacto
     - [BREAKING CHANGE] I renamed NoteCallback to TimelineCallback for timeline events (new note created etc)
     - NoteCallback is now used for note events

I couldn't do unit tests as I saw that we need a live connection to misshub.io to launch tests.
I tested my code in the application where I use your library and it seems to work

Do not hesitate to review and ask for improvments ;)